### PR TITLE
Flashing crosshairs on cursor{line,col}

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ With this little script in your plugins folder if the stuff after the colon is
 a number and a file exists with the name specified before the colon vim will
 open this file and take you to the line you wished in the first place. 
 
+Use this setting to disable the temporary flashing crosshairs on the cursor-line/column:
+
+    let g:file_line_crosshairs=0
+
 ## License
 
 This script is licensed with GPLv3.

--- a/plugin/file_line.vim
+++ b/plugin/file_line.vim
@@ -33,7 +33,16 @@ function! s:goto_file_line(...)
     normal! zv
     normal! zz
     filetype detect
+    call s:crosshair_flash(3)
   endif
 
   return fname
+endfunction
+
+function! s:crosshair_flash(n) abort
+  " Flash crosshairs on current cursor line/column
+  " https://vi.stackexchange.com/a/3481/29697
+  for i in range(1,a:n)
+    set cul cuc | redraw | sleep 200m | set nocul nocuc | redraw | sleep 200m
+  endfor
 endfunction

--- a/plugin/file_line.vim
+++ b/plugin/file_line.vim
@@ -39,10 +39,17 @@ function! s:goto_file_line(...)
   return fname
 endfunction
 
+
+" Flash crosshairs (reticle) on current cursor line/column to highlight it.
+" Particularly useful when the cursor is at head/tail end of file,
+" in which case it will not get centered.
+" Ref1: https://vi.stackexchange.com/a/3481/29697
+" Ref2: https://stackoverflow.com/a/33775128/38281
+let g:file_line_crosshairs = get(g:, 'file_line_crosshairs', 1)
 function! s:crosshair_flash(n) abort
-  " Flash crosshairs on current cursor line/column
-  " https://vi.stackexchange.com/a/3481/29697
-  for i in range(1,a:n)
-    set cul cuc | redraw | sleep 200m | set nocul nocuc | redraw | sleep 200m
-  endfor
+  if g:file_line_crosshairs
+    for i in range(1,a:n)
+      set cul cuc | redraw | sleep 200m | set nocul nocuc | redraw | sleep 200m
+    endfor
+  endif
 endfunction


### PR DESCRIPTION
A flashy but lightweight addition: temporary crosshairs to show cursor{line,column}.

Particularly useful when the cursor is at head/tail end of file, in which case it will not get centered.