### PR TITLE
fix(editorconfig): avoid race condition with builtin editorconfig plugin

### DIFF
--- a/plugin/file_line.vim
+++ b/plugin/file_line.vim
@@ -37,7 +37,6 @@ function! s:goto_file_line(...)
   if filereadable(fname)
     let bufnr = bufnr('%')
     execute 'keepalt edit ' . fnameescape(fname)
-    execute 'bwipeout ' bufnr
 
     execute line
     execute 'normal! ' . col


### PR DESCRIPTION
Summary:
There is currently a race condition with the builtin editorconfig plugin.  Both plugins add a `BufRead` autocmd.  However, the callback for the editorconfig plugin is run after this plugin, but after the bufnr is set.  Since this plugin calls `bwipeout`, the buffer no longer exists when the editorconfig plugin tries to read it.

This commit fixes the issue by removing the `bwipeout` call

Test plan:
1. Install neovim >=0.9 (earlier versions probably work, but this is what I'm running)
2. Install this plugin
3. run `nvim ~/.config/nvim/init.vim:69`

Before this commit: error
```vim
Error detected while processing BufNewFile Autocommands for "*":
Error executing lua callback: /usr/local/share/nvim/runtime/lua/editorconfig.lua:210: Invalid buffer id: 1
stack traceback:
        [C]: in function 'nvim_buf_get_name'
        /usr/local/share/nvim/runtime/lua/editorconfig.lua:210: in function 'config'
        /usr/local/share/nvim/runtime/plugin/editorconfig.lua:11: in function </usr/local/share/nvim/runtime/plugin/editorconfig.
lua:4>
```
(note "Invalid buffer id: 1".  That is because `1` was wiped out and now init.vim is in buffer `2`)

With this commit:
opens the file to the right line number